### PR TITLE
Add support for hyperlinks escape sequences

### DIFF
--- a/lib/strings/ansi.rb
+++ b/lib/strings/ansi.rb
@@ -12,7 +12,12 @@ module Strings
     RESET = "\e[0m"
 
     # The regex to match ANSI codes
-    ANSI_MATCHER = '(\[)?\033(\[)?[;?\d]*[\dA-Za-z]([\];])?'
+    ANSI_MATCHER = %r{
+      (?>(\[)?\033(\[)?[;?\d]*[\dA-Za-z]([\];])?)
+      |
+      # hyperlink opening sequence
+      (?>\033\]8;[^;]*;.*?(\033\\|\07))
+    }x
 
     # Return a copy of string with ANSI characters removed
     #
@@ -26,7 +31,7 @@ module Strings
     #
     # @api public
     def sanitize(string)
-      string.gsub(/#{ANSI_MATCHER}/, '')
+      string.gsub(ANSI_MATCHER, '')
     end
     module_function :sanitize
 
@@ -43,7 +48,7 @@ module Strings
     #
     # @api public
     def ansi?(string)
-      !!(string =~ /#{ANSI_MATCHER}/)
+      !!(string =~ ANSI_MATCHER)
     end
     module_function :ansi?
 
@@ -63,7 +68,7 @@ module Strings
     #
     # @api public
     def only_ansi?(string)
-      !!(string =~ /^(#{ANSI_MATCHER})+$/)
+      !!(string =~ /\A(#{ANSI_MATCHER})+\z/)
     end
     module_function :only_ansi?
   end # ANSI

--- a/spec/unit/only_ansi_spec.rb
+++ b/spec/unit/only_ansi_spec.rb
@@ -16,4 +16,21 @@ RSpec.describe Strings::ANSI, '#only_ansi?' do
   it "reports string with only ansi codes correctly" do
     expect(Strings::ANSI.only_ansi?("\e[33;44m\e[0m")).to eq(true)
   end
+
+  it "correctly checks string containing multiple lines" do
+    expect(Strings::ANSI.only_ansi?("\n\e[33;44m\e[0m")).to eq(false)
+    expect(Strings::ANSI.only_ansi?("\e[33;44m\e[0m\n")).to eq(false)
+    expect(Strings::ANSI.only_ansi?("\n")).to eq(false)
+    expect(Strings::ANSI.only_ansi?("\n\n")).to eq(false)
+  end
+
+  it "reports string containing hyperlink codes with an empty name" do
+    expect(Strings::ANSI.only_ansi?("\e]8;;https://google.com\a\e]8;;\a")).to eq(true)
+    expect(Strings::ANSI.only_ansi?("\e]8;;https://google.com\e\\\e]8;;\e\\")).to eq(true)
+  end
+
+  it "doesn't report string containing hyperlink codes with non-empty name" do
+    expect(Strings::ANSI.only_ansi?("\e]8;;https://google.com\alabel\e]8;;\a")).to eq(false)
+    expect(Strings::ANSI.only_ansi?("\e]8;;https://google.com\e\\label\e]8;;\e\\")).to eq(false)
+  end
 end

--- a/spec/unit/sanitize_spec.rb
+++ b/spec/unit/sanitize_spec.rb
@@ -16,4 +16,27 @@ RSpec.describe Strings::ANSI, '#sanitize' do
       expect(Strings::ANSI.sanitize(code)).to eq(expected)
     end
   end
+
+  context 'when string contains hyperlink escape sequence' do
+    it 'removes escape codes and returns empty string when label is empty' do
+      expect(Strings::ANSI.sanitize("\e]8;;https://google.com\e\\\e]8;;\e\\")).to eq("")
+    end
+
+    it 'removes escape codes and returns label when is present' do
+      expect(Strings::ANSI.sanitize("\e]8;;https://google.com\e\\label\e]8;;\e\\")).to eq("label")
+    end
+
+    it 'removes escape codes correctly when params part is present' do
+      expect(Strings::ANSI.sanitize("\e]8;key1=value1:key2=value2;https://google.com\alabel1\e]8;;\e\\")).to eq("label1")
+      expect(Strings::ANSI.sanitize("\e]8;invalid-params;https://google.com\alabel2\e]8;;\e\\")).to eq("label2")
+    end
+
+    it 'removes escape codes, leaving other characters that are not part of sequence' do
+      expect(Strings::ANSI.sanitize("before_\e]8;;https://google.com\alabel\e]8;;\a_after")).to eq("before_label_after")
+    end
+
+    it 'correctly removes escape codes when non-standard \a terminator is used' do
+      expect(Strings::ANSI.sanitize("before_\e]8;;https://google.com\alabel\e]8;;\e\\_after")).to eq("before_label_after")
+    end
+  end
 end


### PR DESCRIPTION
### Describe the change

This PR adds support for hyperlinks escape codes. You can read about them here: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda

### Why are we doing this?

Without this change I can't use `tty-table` library to display cells with a hyperlink. Here is a simple code that shows the problem:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'strings-ansi'
  gem 'tty-table'
  gem 'tty-link'
end

rows = [
  [1, TTY::Link.link_to('google', 'https://google.com')],
  [2, TTY::Link.link_to('duckduckgo', 'https://duckduckgo.com')],
  [3, TTY::Link.link_to('bing', 'https://www.bing.com')],
]

puts TTY::Table.new(nil, rows).render(:ascii)
```

When I run this code I get:

```
ruby bug.rb
+-+------------------------------------------+
|1|google        |
|2|duckduckgo|
|3|bing        |
+-+------------------------------------------+
```

This is because `tty-table` needs to know what is the length of 'visible part' of a string and it can't calculate that properly for strings containing hyperlinks codes. After this fix it displays them correctly.

### Benefits

Support for hyperlinks in `tty-table` and other gems that use `strings-ansi` gem.

### Drawbacks
Possible drawbacks applying this change.

### Requirements

Put an X between brackets on each line if you have done the item:
* [x] Tests written & passing locally?
* [ ] Code style checked?
* [x] Rebased with `master` branch?
* [ ] Documentaion updated?
