### PR TITLE
Version 0.2.1

### DIFF
--- a/lib/strings/ansi/version.rb
+++ b/lib/strings/ansi/version.rb
@@ -2,6 +2,6 @@
 
 module Strings
   module ANSI
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end # ANSI
 end # Strings


### PR DESCRIPTION
There were a bunch of fixes in 2021 that were never officially released, so this does the official version bump to 0.2.1: https://github.com/piotrmurach/strings-ansi/compare/v0.2.0...HEAD

Fixes https://github.com/piotrmurach/strings/issues/21 , which was fixed in 35d0c9430cf0a8022dc12bdab005bce296cb9f00

(after this is merged, it'd require the tag and `gem build/push`, of course)
